### PR TITLE
feat: add payment sandbox and e2e fixtures

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    specPattern: 'cypress/e2e/**/*.cy.js',
+  },
+});

--- a/cypress/e2e/payment_sandbox.cy.js
+++ b/cypress/e2e/payment_sandbox.cy.js
@@ -1,0 +1,15 @@
+// cypress/e2e/payment_sandbox.cy.js
+// Basic E2E tests ensuring the sandbox endpoint provides
+// mock payloads for payment statuses.
+
+describe('Payment sandbox', () => {
+  const statuses = ['approved', 'rejected', 'pending'];
+
+  statuses.forEach((status) => {
+    it(`returns ${status} payload`, () => {
+      cy.fixture(`payment-${status}.json`).then((expected) => {
+        cy.request(`/payments/mp/sandbox/${status}`).its('body').should('deep.equal', expected);
+      });
+    });
+  });
+});

--- a/cypress/fixtures/payment-approved.json
+++ b/cypress/fixtures/payment-approved.json
@@ -1,0 +1,4 @@
+{
+  "paymentId": "sandbox-payment-approved",
+  "status": "approved"
+}

--- a/cypress/fixtures/payment-pending.json
+++ b/cypress/fixtures/payment-pending.json
@@ -1,0 +1,4 @@
+{
+  "paymentId": "sandbox-payment-pending",
+  "status": "pending"
+}

--- a/cypress/fixtures/payment-rejected.json
+++ b/cypress/fixtures/payment-rejected.json
@@ -1,0 +1,4 @@
+{
+  "paymentId": "sandbox-payment-rejected",
+  "status": "rejected"
+}

--- a/ecommerce-backend/src/modules/payments/controller.js
+++ b/ecommerce-backend/src/modules/payments/controller.js
@@ -88,3 +88,16 @@ exports.handleWebhook = async (req, res, next) => {
     next(err);
   }
 };
+// GET /payments/mp/sandbox/:status
+// Returns mock webhook payloads to simulate Mercado Pago events in tests.
+const sandbox = require('./sandbox');
+exports.getSandboxPayment = (req, res, next) => {
+  try {
+    const { status } = req.params;
+    const payload = sandbox[status];
+    if (!payload) throw new ApiError('Invalid status', 400);
+    res.json(payload);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/ecommerce-backend/src/modules/payments/router.js
+++ b/ecommerce-backend/src/modules/payments/router.js
@@ -12,4 +12,7 @@ router.post('/mp/preference', controller.createPreference);
 // POST /payments/mp/webhooks
 router.post('/mp/webhooks', controller.handleWebhook);
 
+// GET /payments/mp/sandbox/:status
+router.get('/mp/sandbox/:status', controller.getSandboxPayment);
+
 module.exports = router;

--- a/ecommerce-backend/src/modules/payments/sandbox.js
+++ b/ecommerce-backend/src/modules/payments/sandbox.js
@@ -1,0 +1,18 @@
+// src/modules/payments/sandbox.js
+// Mock Mercado Pago webhook payloads used for E2E testing.
+// Provides static examples for approved, rejected and pending payments.
+
+module.exports = {
+  approved: {
+    paymentId: 'sandbox-payment-approved',
+    status: 'approved',
+  },
+  rejected: {
+    paymentId: 'sandbox-payment-rejected',
+    status: 'rejected',
+  },
+  pending: {
+    paymentId: 'sandbox-payment-pending',
+    status: 'pending',
+  },
+};


### PR DESCRIPTION
## Summary
- add mock Mercado Pago sandbox payloads for testing
- expose sandbox route for payment status examples
- create Cypress fixtures and tests for approved, rejected, and pending

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: react-scripts not found)*
- `npx cypress run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5d5272008323935fd64243bac7dc