### PR TITLE
docs: add backend, frontend and root setup readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# lego_app
+# Lego Ecommerce Monorepo
+
+Repositorio que agrupa el backend y frontend de una tienda B2C de Lego.
+
+## Requisitos
+
+- Node.js 18+
+- npm
+
+## Estructura del repositorio
+
+```
+├── ecommerce-backend/   # API en Node.js, Express y GraphQL
+├── ecommerce-frontend/  # Aplicación web en React
+├── cypress/             # Pruebas end-to-end con Cypress
+└── cypress.config.js    # Configuración de Cypress
+```
+
+## Configuración
+
+1. Clonar este repositorio.
+2. Instalar dependencias en cada paquete:
+   ```bash
+   cd ecommerce-backend && npm install
+   cd ../ecommerce-frontend && npm install
+   ```
+
+## Ejecución
+
+- **Backend**
+  ```bash
+  cd ecommerce-backend
+  npm run dev    # modo desarrollo
+  npm start      # modo producción
+  ```
+- **Frontend**
+  ```bash
+  cd ecommerce-frontend
+  npm start      # servidor de desarrollo
+  npm run build  # compilación para producción
+  ```
+
+## Pruebas
+
+- **Backend**: `cd ecommerce-backend && npm test`
+- **Frontend**: `cd ecommerce-frontend && npm test`
+- **End-to-end**: con el backend y frontend ejecutándose, correr `npx cypress run`
+
+Para más detalles de variables de entorno y estructuras internas, revisar los README de cada paquete.

--- a/ecommerce-backend/README.md
+++ b/ecommerce-backend/README.md
@@ -1,0 +1,63 @@
+# Lego Ecommerce Backend
+
+Service de backend para una tienda B2C de Lego construido con Node.js, Express y GraphQL.
+
+## Requisitos
+
+- Node.js 18+
+- npm
+
+## Instalación
+
+1. Instalar dependencias:
+   ```bash
+   npm install
+   ```
+2. Crear un archivo `.env` en la raíz del proyecto con las variables necesarias. Ejemplo:
+   ```env
+   PORT=3000
+   DB_URI=sqlite::memory:
+   JWT_SECRET=cambia_este_secreto
+   GOOGLE_CLIENT_ID=
+   GOOGLE_CLIENT_SECRET=
+   FACEBOOK_APP_ID=
+   FACEBOOK_APP_SECRET=
+   MP_ACCESS_TOKEN=
+   CLOUDINARY_CLOUD_NAME=
+   CLOUDINARY_API_KEY=
+   CLOUDINARY_API_SECRET=
+   ```
+3. (Opcional) Poblar la base de datos con datos de ejemplo:
+   ```bash
+   npm run seed
+   ```
+
+## Ejecución
+
+- Modo desarrollo con recarga automática:
+  ```bash
+  npm run dev
+  ```
+- Modo producción:
+  ```bash
+  npm start
+  ```
+
+## Pruebas
+
+Ejecutar los tests unitarios:
+```bash
+npm test
+```
+
+## Estructura del proyecto
+
+```
+src/
+  app/        Configuración y arranque del servidor
+  config/     Configuración de entorno y base de datos
+  graphql/    Definiciones del esquema y resolvers GraphQL
+  infra/      Servicios externos, modelos y seeds
+  modules/    Lógica de negocio organizada por módulos
+  shared/     Utilidades compartidas
+```

--- a/ecommerce-frontend/README.md
+++ b/ecommerce-frontend/README.md
@@ -1,0 +1,50 @@
+# Lego Ecommerce Frontend
+
+Aplicación web en React para la tienda B2C de Lego.
+
+## Requisitos
+
+- Node.js 18+
+- npm
+
+## Instalación
+
+1. Instalar dependencias:
+   ```bash
+   npm install
+   ```
+2. Configurar variables de entorno en un archivo `.env` (opcional):
+   ```env
+   REACT_APP_API_URL=http://localhost:3000
+   ```
+
+## Ejecución
+
+- Servidor de desarrollo:
+  ```bash
+  npm start
+  ```
+- Compilación para producción:
+  ```bash
+  npm run build
+  ```
+
+## Pruebas
+
+Ejecutar los tests de la aplicación:
+```bash
+npm test
+```
+
+## Estructura del proyecto
+
+```
+public/                 Archivos estáticos y plantilla HTML
+src/
+  components/           Componentes reutilizables
+  contexts/             Contextos de React
+  pages/                Páginas principales de la aplicación
+  services/             Clientes y utilidades para APIs
+  App.js                Componente raíz
+  index.js              Punto de entrada
+```


### PR DESCRIPTION
## Summary
- add detailed README for backend with env vars, dev/prod commands and structure
- add README for frontend with setup instructions and project layout
- document repository root with overall structure, install and test guidance

## Testing
- `npm test` (backend)
- `npm install` (frontend) *(fails: 403 Forbidden - tsutils)*
- `CI=true npm test` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f06f8f08323a94a2efdcb2bc687