### PR TITLE
Fix eager loading aliases in catalog controller

### DIFF
--- a/ecommerce-backend/src/modules/catalog/controller.js
+++ b/ecommerce-backend/src/modules/catalog/controller.js
@@ -40,13 +40,14 @@ exports.getProducts = async (req, res, next) => {
     if (theme) {
       include.push({
         model: Category,
+        as: 'categories',
         where: { name: { [Op.iLike]: `%${theme}%` } },
         through: { attributes: [] },
       });
     }
 
-    include.push({ model: Category, through: { attributes: [] } });
-    include.push({ model: Review, include: [User] });
+    include.push({ model: Category, as: 'categories', through: { attributes: [] } });
+    include.push({ model: Review, as: 'reviews', include: [User] });
 
     const pageNum = parseInt(page, 10) || 1;
     const limitNum = parseInt(limit, 10) || 10;
@@ -83,8 +84,8 @@ exports.getProductById = async (req, res, next) => {
     const { id } = req.params;
     const product = await Product.findByPk(id, {
       include: [
-        { model: Category, through: { attributes: [] } },
-        { model: Review, include: [User] },
+        { model: Category, as: 'categories', through: { attributes: [] } },
+        { model: Review, as: 'reviews', include: [User] },
       ],
     });
     if (!product) throw new ApiError('Product not found', 404);


### PR DESCRIPTION
## Summary
- include Category and Review associations with explicit `as` aliases to match Sequelize definitions

## Testing
- `node --test test/productsController.test.js`
- `npm install` *(fails: 403 Forbidden fetching packages)*

