### PR TITLE
feat: enable chokidar polling for frontend dev

### DIFF
--- a/ecommerce-frontend/package.json
+++ b/ecommerce-frontend/package.json
@@ -5,7 +5,7 @@
   "description": "Frontend para un ecommerce B2C de Legos (React)",
   "proxy": "http://localhost:4000",
   "scripts": {
-    "start": "react-scripts start",
+    "start": "CHOKIDAR_USEPOLLING=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## Summary
- use CHOKIDAR_USEPOLLING in React start script so watcher works via polling

## Testing
- `CI=true npm test`
- `npm start`

------