### PR TITLE
feat(theme): lego-inspired palette from logo + bootstrap theme (light/dark)

### DIFF
--- a/ecommerce-frontend/README.md
+++ b/ecommerce-frontend/README.md
@@ -64,3 +64,15 @@ src/
   App.js                Componente raíz
   index.js              Punto de entrada
 ```
+
+## Tema y paleta
+
+Los colores del tema se extraen del logo y se armonizan con los tonos clásicos de Lego.
+Para regenerar los tokens ejecutá:
+
+```bash
+node ../scripts/extract-palette.mjs
+```
+
+Esto generará `src/theme/tokens.json`. Podés editar este archivo para extender
+los colores semánticos o ajustar valores específicos.

--- a/ecommerce-frontend/package.json
+++ b/ecommerce-frontend/package.json
@@ -9,7 +9,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lhci": "lhci autorun"
+    "lhci": "lhci autorun",
+    "extract-palette": "node ../scripts/extract-palette.mjs"
   },
   "dependencies": {
     "bootstrap": "^5.3.0",
@@ -23,7 +24,9 @@
     "react-toastify": "^9.1.3"
   },
   "devDependencies": {
-    "eslint-plugin-react-hooks": "^4.6.2"
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "sass": "^1.69.0",
+    "node-vibrant": "^3.2.0"
   },
   "eslintConfig": {
     "extends": [

--- a/ecommerce-frontend/public/index.html
+++ b/ecommerce-frontend/public/index.html
@@ -8,16 +8,9 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" content="#0d6efd" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-ENjdO4Dr2bkBIFxQpeo7FQ3oq5WLWfYp6Qx85a9+YdY/2JoBlz96K8+p3T0sOQvE"
-      crossorigin="anonymous"
-    />
+    <meta name="theme-color" content="#DA1A32" />
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-wnmFs0tL1lj9ny1sIgy3T+6rxKcHwwLzK2wUiJZl0KbnUPXahYf2059Fup5B2LFi" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/ecommerce-frontend/public/site.webmanifest
+++ b/ecommerce-frontend/public/site.webmanifest
@@ -1,12 +1,10 @@
-<<<<<<< HEAD
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
-=======
 {
   "name": "Brick Market",
   "icons": [
     { "src": "/favicon-32.png", "sizes": "32x32", "type": "image/png" },
     { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" }
   ],
-  "theme_color": "#0d6efd"
+  "theme_color": "#DA1A32",
+  "background_color": "#DA1A32",
+  "display": "standalone"
 }
->>>>>>> 9fa691b2c8dd06672cb45a1a48810288fdd81ff8

--- a/ecommerce-frontend/src/App.js
+++ b/ecommerce-frontend/src/App.js
@@ -14,6 +14,7 @@ import LoginCallback from './pages/LoginCallback';
 import OrdersPage from './pages/OrdersPage';
 import AdminPage from './pages/AdminPage';
 import WishlistPage from './pages/WishlistPage';
+import Styleguide from './pages/Styleguide';
 import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
@@ -61,6 +62,7 @@ function App() {
               </ProtectedRoute>
             }
           />
+          <Route path="/styleguide" element={<Styleguide />} />
         </Routes>
       </div>
       <ToastContainer position="bottom-right" />

--- a/ecommerce-frontend/src/components/Navbar.js
+++ b/ecommerce-frontend/src/components/Navbar.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import MiniCart from './MiniCart';
+import ThemeToggle from './ThemeToggle';
 import * as api from '../services/api';
 
 // Navigation bar component. Uses Bootstrap classes for styling.
@@ -22,7 +23,7 @@ function Navbar() {
     loadCart();
   }, [user]);
   return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-light">
+    <nav className="navbar navbar-expand-lg navbar-light bg-body">
       <div className="container-fluid">
         <Link className="navbar-brand" to="/" aria-label="Inicio">
           <img
@@ -107,6 +108,9 @@ function Navbar() {
                 </Link>
               </li>
             )}
+            <li className="nav-item ms-2">
+              <ThemeToggle />
+            </li>
           </ul>
         </div>
       </div>

--- a/ecommerce-frontend/src/components/ThemeToggle.js
+++ b/ecommerce-frontend/src/components/ThemeToggle.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = saved || (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <button
+      type="button"
+      className="btn btn-outline-secondary"
+      onClick={toggle}
+      aria-label="Cambiar tema"
+    >
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/ecommerce-frontend/src/index.js
+++ b/ecommerce-frontend/src/index.js
@@ -2,7 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './contexts/AuthContext';
-import 'bootstrap/dist/css/bootstrap.min.css';
+import './theme/variables.css';
+import './theme/bootstrap.scss';
+import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/ecommerce-frontend/src/pages/LoginPage.jsx
+++ b/ecommerce-frontend/src/pages/LoginPage.jsx
@@ -77,7 +77,7 @@ const LoginPage = () => {
       </form>
       <hr />
       <button
-        className="btn btn-outline-dark w-100"
+        className="btn btn-outline-secondary w-100"
         onClick={loginWithGoogle}
         aria-label="Continuar con Google"
       >

--- a/ecommerce-frontend/src/pages/Styleguide.js
+++ b/ecommerce-frontend/src/pages/Styleguide.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import tokens from '../theme/tokens.json';
+
+const hexToRgb = (hex) => {
+  const s = hex.replace('#', '');
+  const num = parseInt(s, 16);
+  return [num >> 16 & 255, num >> 8 & 255, num & 255];
+};
+
+const luminance = (r, g, b) => {
+  const a = [r, g, b].map(v => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+};
+
+const contrast = (hex1, hex2) => {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const l1 = luminance(r1, g1, b1) + 0.05;
+  const l2 = luminance(r2, g2, b2) + 0.05;
+  return l1 > l2 ? l1 / l2 : l2 / l1;
+};
+
+const Swatch = ({ name, value }) => {
+  const ratio = contrast(value.hex, '#ffffff').toFixed(2);
+  const textColor = ratio >= 4.5 ? '#ffffff' : '#000000';
+  return (
+    <div className="p-3 text-center" style={{ background: value.hex, color: textColor }}>
+      <div className="small text-uppercase">{name}</div>
+      <div>{value.hex}</div>
+      <div className="small">{ratio}:1</div>
+    </div>
+  );
+};
+
+const Styleguide = () => {
+  return (
+    <div className="container py-4">
+      <h1>Styleguide</h1>
+      <h2 className="mt-4">Colores de marca</h2>
+      <div className="row g-2 mb-4">
+        {Object.entries(tokens.brand).map(([name, value]) => (
+          <div key={name} className="col-6 col-md-4 col-lg-3">
+            <Swatch name={name} value={value} />
+          </div>
+        ))}
+      </div>
+      <h2>Botones</h2>
+      <button className="btn btn-primary me-2">Primary</button>
+      <button className="btn btn-secondary me-2">Secondary</button>
+      <button className="btn btn-accent me-2">Accent</button>
+      <h2 className="mt-4">Inputs</h2>
+      <input className="form-control mb-3" placeholder="Input" />
+      <h2>Alerts</h2>
+      <div className="alert alert-primary">Primary alert</div>
+      <div className="alert alert-success">Success alert</div>
+      <div className="alert alert-warning">Warning alert</div>
+      <div className="alert alert-danger">Danger alert</div>
+      <h2>Badges</h2>
+      <span className="badge text-bg-primary me-2">Primary</span>
+      <span className="badge text-bg-success me-2">Success</span>
+      <span className="badge text-bg-warning me-2">Warning</span>
+      <span className="badge text-bg-danger me-2">Danger</span>
+      <h2 className="mt-4">Cards</h2>
+      <div className="card p-3">Card content</div>
+    </div>
+  );
+};
+
+export default Styleguide;

--- a/ecommerce-frontend/src/theme/bootstrap.scss
+++ b/ecommerce-frontend/src/theme/bootstrap.scss
@@ -1,0 +1,20 @@
+$primary: var(--color-primary);
+$secondary: var(--color-secondary);
+$success: var(--color-success);
+$warning: var(--color-warning);
+$danger: var(--color-danger);
+$info: var(--color-info);
+$body-bg: var(--bg);
+$body-color: var(--fg);
+$link-color: var(--link);
+$link-hover-color: var(--link-hover);
+$btn-border-radius: .5rem;
+$input-border-color: var(--border);
+$navbar-light-color: var(--fg);
+$navbar-light-brand-color: var(--fg);
+$card-border-color: var(--border);
+$alert-bg-scale: 0;
+$alert-border-scale: 0;
+$alert-color-scale: 0;
+
+@import "bootstrap/scss/bootstrap";

--- a/ecommerce-frontend/src/theme/tokens.json
+++ b/ecommerce-frontend/src/theme/tokens.json
@@ -1,0 +1,20 @@
+{
+  "brand": {
+    "primary": { "hex": "#DA1A32", "hsl": "348 84% 48%" },
+    "secondary": { "hex": "#FFCF00", "hsl": "45 100% 50%" },
+    "accent": { "hex": "#0057A6", "hsl": "211 100% 33%" },
+    "support1": { "hex": "#008F4B", "hsl": "152 100% 28%" },
+    "support2": { "hex": "#F06D1F", "hsl": "20 87% 54%" }
+  },
+  "neutral": {
+    "0": "#ffffff",
+    "50": "#f8f9fa",
+    "900": "#111827"
+  },
+  "semantic": {
+    "success": "#22c55e",
+    "warning": "#f59e0b",
+    "danger": "#ef4444",
+    "info": "#0ea5e9"
+  }
+}

--- a/ecommerce-frontend/src/theme/variables.css
+++ b/ecommerce-frontend/src/theme/variables.css
@@ -1,0 +1,75 @@
+:root {
+  --color-primary-hsl: 348 84% 48%;
+  --color-primary: hsl(var(--color-primary-hsl));
+  --color-secondary-hsl: 45 100% 50%;
+  --color-secondary: hsl(var(--color-secondary-hsl));
+  --color-accent-hsl: 211 100% 33%;
+  --color-accent: hsl(var(--color-accent-hsl));
+  --color-success-hsl: 142 72% 45%;
+  --color-success: hsl(var(--color-success-hsl));
+  --color-warning-hsl: 35 92% 56%;
+  --color-warning: hsl(var(--color-warning-hsl));
+  --color-danger-hsl: 0 84% 60%;
+  --color-danger: hsl(var(--color-danger-hsl));
+  --color-info-hsl: 199 90% 48%;
+  --color-info: hsl(var(--color-info-hsl));
+
+  --bg: #ffffff;
+  --fg: #111827;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+
+  --link: var(--color-primary);
+  --link-hover: var(--color-accent);
+}
+
+[data-theme="dark"] {
+  --bg: #111827;
+  --fg: #f8f9fa;
+  --muted: #9ca3af;
+  --border: #374151;
+  --link: var(--color-secondary);
+  --link-hover: var(--color-accent);
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+a {
+  color: var(--link);
+}
+a:hover {
+  color: var(--link-hover);
+}
+
+.nav-link {
+  color: var(--fg);
+}
+.nav-link:hover,
+.nav-link:focus {
+  color: var(--link-hover);
+  text-decoration: underline;
+}
+
+.card {
+  border-color: var(--border);
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+.form-control:focus {
+  box-shadow: 0 0 0 0.25rem hsl(var(--color-primary-hsl) / 0.25);
+  border-color: var(--color-primary);
+}
+
+.btn-accent {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+.btn-accent:hover {
+  background-color: color-mix(in srgb, var(--color-accent), black 20%);
+  border-color: color-mix(in srgb, var(--color-accent), black 20%);
+}

--- a/scripts/extract-palette.mjs
+++ b/scripts/extract-palette.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import Vibrant from 'node-vibrant';
+import fs from 'fs';
+import path from 'path';
+
+const image = path.resolve('ecommerce-frontend/public/assets/logo.png');
+
+const legoFallback = {
+  primary: '#DA1A32',
+  secondary: '#FFCF00',
+  accent: '#0057A6',
+  support1: '#008F4B',
+  support2: '#F06D1F'
+};
+
+function hexToRgb(hex) {
+  const s = hex.replace('#', '');
+  const num = parseInt(s, 16);
+  return [num >> 16 & 255, num >> 8 & 255, num & 255];
+}
+
+function rgbToHsl(r, g, b) {
+  r /= 255; g /= 255; b /= 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h, s, l = (max + min) / 2;
+  if (max === min) {
+    h = s = 0;
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+      case g: h = (b - r) / d + 2; break;
+      case b: h = (r - g) / d + 4; break;
+    }
+    h /= 6;
+  }
+  return [h * 360, s * 100, l * 100];
+}
+
+function hslToRgb(h, s, l) {
+  h /= 360; s /= 100; l /= 100;
+  let r, g, b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1/6) return p + (q - p) * 6 * t;
+      if (t < 1/2) return q;
+      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1/3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1/3);
+  }
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
+function rgbToHex(r, g, b) {
+  return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+function luminance(r, g, b) {
+  const a = [r, g, b].map(v => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+}
+
+function contrast(hex1, hex2) {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const l1 = luminance(r1, g1, b1) + 0.05;
+  const l2 = luminance(r2, g2, b2) + 0.05;
+  return l1 > l2 ? l1 / l2 : l2 / l1;
+}
+
+function ensureContrast(hex, against = '#ffffff', ratio = 4.5) {
+  let [h, s, l] = rgbToHsl(...hexToRgb(hex));
+  while (contrast(rgbToHex(...hslToRgb(h, s, l)), against) < ratio && l < 95) {
+    l += 1;
+  }
+  const [r, g, b] = hslToRgb(h, s, l);
+  const newHex = rgbToHex(r, g, b);
+  return { hex: newHex, hsl: `${Math.round(h)} ${Math.round(s)}% ${Math.round(l)}%` };
+}
+
+const palette = await Vibrant.from(image).getPalette();
+const pick = (swatch, fallback) => (swatch ? swatch.hex : fallback);
+
+const tokens = {
+  brand: {
+    primary: ensureContrast(pick(palette.Vibrant, legoFallback.primary)),
+    secondary: ensureContrast(pick(palette.LightVibrant, legoFallback.secondary)),
+    accent: ensureContrast(pick(palette.Muted, legoFallback.accent)),
+    support1: ensureContrast(pick(palette.DarkVibrant, legoFallback.support1)),
+    support2: ensureContrast(pick(palette.DarkMuted, legoFallback.support2))
+  },
+  neutral: {
+    "0": "#ffffff",
+    "50": "#f8f9fa",
+    "900": "#111827"
+  },
+  semantic: {
+    success: "#22c55e",
+    warning: "#f59e0b",
+    danger: "#ef4444",
+    info: "#0ea5e9"
+  }
+};
+
+fs.writeFileSync(
+  path.resolve('ecommerce-frontend/src/theme/tokens.json'),
+  JSON.stringify(tokens, null, 2)
+);
+
+console.log('Tokens generated at src/theme/tokens.json');


### PR DESCRIPTION
## Summary
- extract palette from logo and output color tokens
- add css variables and bootstrap overrides for light/dark theme
- include theme toggle, styleguide and branding metadata

## Testing
- `npm test -- --watchAll=false`
- `npm run build` *(fails: Cannot find module 'sass')*

------
https://chatgpt.com/codex/tasks/task_e_68aad82e965483239d43fd5d38170a17