### PR TITLE
Add persistent dark mode and Font Awesome icons

### DIFF
--- a/ecommerce-frontend/public/index.html
+++ b/ecommerce-frontend/public/index.html
@@ -9,6 +9,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#DA1A32" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/ecommerce-frontend/src/components/Navbar.js
+++ b/ecommerce-frontend/src/components/Navbar.js
@@ -23,7 +23,7 @@ function Navbar() {
     loadCart();
   }, [user]);
   return (
-    <nav className="navbar navbar-expand-lg navbar-light bg-body">
+    <nav className="navbar navbar-expand-lg navbar-dark bg-primary">
       <div className="container-fluid">
         <Link className="navbar-brand" to="/" aria-label="Inicio">
           <img
@@ -77,14 +77,15 @@ function Navbar() {
           <ul className="navbar-nav ms-auto">
             <li className="nav-item dropdown">
               <Link
-                className="nav-link dropdown-toggle"
+                className="nav-link dropdown-toggle d-flex align-items-center"
                 to="/cart"
                 id="miniCartDropdown"
                 role="button"
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
               >
-                Carrito
+                <i className="fa-solid fa-cart-shopping me-1" aria-hidden="true"></i>
+                <span>Carrito</span>
               </Link>
               <div className="dropdown-menu dropdown-menu-end" aria-labelledby="miniCartDropdown">
                 <MiniCart items={cart?.items || []} />
@@ -93,18 +94,23 @@ function Navbar() {
             {user ? (
               <>
                 <li className="nav-item">
-                  <span className="nav-link">Hola, {user.name}</span>
+                  <span className="nav-link">
+                    <i className="fa-solid fa-user me-1" aria-hidden="true"></i>
+                    Hola, {user.name}
+                  </span>
                 </li>
                 <li className="nav-item">
                   <button onClick={logout} className="btn btn-link nav-link">
+                    <i className="fa-solid fa-right-from-bracket me-1" aria-hidden="true"></i>
                     Salir
                   </button>
                 </li>
               </>
             ) : (
               <li className="nav-item">
-                <Link className="nav-link" to="/login">
-                  Iniciar sesión
+                <Link className="nav-link d-flex align-items-center" to="/login">
+                  <i className="fa-solid fa-right-to-bracket me-1" aria-hidden="true"></i>
+                  <span>Iniciar sesión</span>
                 </Link>
               </li>
             )}

--- a/ecommerce-frontend/src/components/ThemeToggle.js
+++ b/ecommerce-frontend/src/components/ThemeToggle.js
@@ -8,12 +8,23 @@ const ThemeToggle = () => {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const initial = saved || (prefersDark ? 'dark' : 'light');
     setTheme(initial);
+    applyTheme(initial);
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
+    applyTheme(theme);
     localStorage.setItem('theme', theme);
   }, [theme]);
+
+  const applyTheme = (t) => {
+    if (t === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      document.documentElement.style.colorScheme = 'dark';
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+      document.documentElement.style.colorScheme = 'light';
+    }
+  };
 
   const toggle = () => {
     setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
@@ -22,11 +33,15 @@ const ThemeToggle = () => {
   return (
     <button
       type="button"
-      className="btn btn-outline-secondary"
+      className="btn btn-outline-light d-flex align-items-center"
       onClick={toggle}
-      aria-label="Cambiar tema"
+      aria-label={`Cambiar a modo ${theme === 'dark' ? 'claro' : 'oscuro'}`}
     >
-      {theme === 'dark' ? '🌙' : '☀️'}
+      <i
+        className={`fa-solid ${theme === 'dark' ? 'fa-sun' : 'fa-moon'}`}
+        aria-hidden="true"
+      ></i>
+      <span className="ms-2">{theme === 'dark' ? 'Claro' : 'Oscuro'}</span>
     </button>
   );
 };

--- a/ecommerce-frontend/src/pages/LoginPage.jsx
+++ b/ecommerce-frontend/src/pages/LoginPage.jsx
@@ -67,28 +67,22 @@ const LoginPage = () => {
         </div>
         {error && <p className="text-danger">{error}</p>}
         <button
-          className="btn btn-primary w-100"
+          className="btn btn-primary w-100 d-flex align-items-center justify-content-center"
           disabled={loading}
           type="submit"
           aria-label="Ingresar"
         >
+          <i className="fa-solid fa-right-to-bracket me-2" aria-hidden="true"></i>
           {loading ? 'Ingresando…' : 'Ingresar'}
         </button>
       </form>
       <hr />
       <button
-        className="btn btn-outline-secondary w-100"
+        className="btn btn-outline-secondary w-100 d-flex align-items-center justify-content-center"
         onClick={loginWithGoogle}
         aria-label="Continuar con Google"
       >
-        <span className="me-2" aria-hidden="true">
-          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-            <path fill="#EA4335" d="M9 3.48c1.69 0 2.83.73 3.48 1.34l2.56-2.56C13.55.8 11.48 0 9 0 5.48 0 2.44 2.02.96 5l2.9 2.26C4.45 5.09 6.55 3.48 9 3.48z"/>
-            <path fill="#FBBC05" d="M17.64 9.2c0-.74-.06-1.29-.2-1.86H9v3.38h4.9c-.1.84-.64 2.1-1.84 2.94l2.84 2.2c1.7-1.57 2.74-3.88 2.74-6.66z"/>
-            <path fill="#34A853" d="M3.86 10.74c-.44-1.31-.44-2.72 0-4.03L.96 4.45C-.32 6.9-.32 9.94.96 12.4l2.9-2.26z"/>
-            <path fill="#4285F4" d="M9 18c2.48 0 4.55-.8 6.06-2.18l-2.84-2.2c-.73.5-1.7.85-3.22.85-2.45 0-4.55-1.61-5.14-3.74l-2.9 2.26C2.44 15.98 5.48 18 9 18z"/>
-          </svg>
-        </span>
+        <i className="fa-brands fa-google me-2" aria-hidden="true"></i>
         Continuar con Google
       </button>
     </AuthCard>

--- a/ecommerce-frontend/src/pages/RegisterPage.jsx
+++ b/ecommerce-frontend/src/pages/RegisterPage.jsx
@@ -106,11 +106,12 @@ const RegisterPage = () => {
           {errors.confirmPassword && <div className="invalid-feedback">{errors.confirmPassword}</div>}
         </div>
         <button
-          className="btn btn-primary w-100"
+          className="btn btn-primary w-100 d-flex align-items-center justify-content-center"
           disabled={loading}
           type="submit"
           aria-label="Registrarse"
         >
+          <i className="fa-solid fa-user-plus me-2" aria-hidden="true"></i>
           {loading ? 'Registrando…' : 'Registrarse'}
         </button>
       </form>

--- a/ecommerce-frontend/src/theme/variables.css
+++ b/ecommerce-frontend/src/theme/variables.css
@@ -33,13 +33,12 @@
   --bs-link-color: var(--link);
   --bs-link-hover-color: var(--link-hover);
   --bs-border-color: var(--border);
-  --bs-navbar-color: var(--fg);
-  --bs-navbar-brand-color: var(--fg);
   --bs-card-bg: var(--bg);
   --bs-card-color: var(--fg);
   --bs-card-border-color: var(--border);
   --bs-border-radius: 0.5rem;
   --bs-btn-border-radius: 0.5rem;
+  color-scheme: light;
 }
 
 [data-theme="dark"] {
@@ -55,11 +54,10 @@
   --bs-link-color: var(--link);
   --bs-link-hover-color: var(--link-hover);
   --bs-border-color: var(--border);
-  --bs-navbar-color: var(--fg);
-  --bs-navbar-brand-color: var(--fg);
   --bs-card-bg: var(--bg);
   --bs-card-color: var(--fg);
   --bs-card-border-color: var(--border);
+  color-scheme: dark;
 }
 
 body {
@@ -67,21 +65,12 @@ body {
   color: var(--fg);
 }
 
-a {
+ a {
   color: var(--link);
-}
-a:hover {
+ }
+ a:hover {
   color: var(--link-hover);
-}
-
-.nav-link {
-  color: var(--fg);
-}
-.nav-link:hover,
-.nav-link:focus {
-  color: var(--link-hover);
-  text-decoration: underline;
-}
+ }
 
 .card {
   border-color: var(--border);
@@ -102,4 +91,16 @@ a:hover {
 .btn-accent:hover {
   background-color: color-mix(in srgb, var(--color-accent), black 20%);
   border-color: color-mix(in srgb, var(--color-accent), black 20%);
+}
+
+.btn-outline-warning {
+  color: #212529;
+  background-color: var(--color-warning);
+  border-color: var(--color-warning);
+}
+.btn-outline-warning:hover,
+.btn-outline-warning:focus {
+  color: #212529;
+  background-color: color-mix(in srgb, var(--color-warning), black 10%);
+  border-color: color-mix(in srgb, var(--color-warning), black 15%);
 }


### PR DESCRIPTION
## Summary
- implement persistent light/dark mode toggle with system preference detection
- style navbar with primary background and include Font Awesome icons
- replace low-contrast warning outline with solid accessible style

## Testing
- ⚠️ `npm install` (403 Forbidden fetching @fortawesome/fontawesome-free)
- ✅ `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae93443f8832389340cbf23f830cc