### PR TITLE
Remove legacy CSRF middleware

### DIFF
--- a/ecommerce-backend/src/modules/auth/controller.js
+++ b/ecommerce-backend/src/modules/auth/controller.js
@@ -150,8 +150,9 @@ exports.me = (req, res) => {
 exports.csrfToken = (_req, res) => {
   const token = crypto.randomBytes(16).toString('hex');
   res.cookie('csrfToken', token, {
+    httpOnly: true,
     sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
+    secure: true,
     domain: process.env.COOKIE_DOMAIN || undefined,
   });
   res.json({ csrfToken: token });

--- a/ecommerce-backend/src/modules/auth/service.js
+++ b/ecommerce-backend/src/modules/auth/service.js
@@ -52,11 +52,7 @@ function setAuthCookies(res, { accessToken, refreshToken, csrfToken }) {
     ...base,
     maxAge: parseDuration(process.env.REFRESH_TOKEN_TTL || '30d'),
   });
-  res.cookie('csrfToken', csrfToken, {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-    domain: process.env.COOKIE_DOMAIN || undefined,
-  });
+  res.cookie('csrfToken', csrfToken, { ...base, secure: true });
 }
 
 function clearAuthCookies(res) {

--- a/ecommerce-backend/src/shared/middlewares.js
+++ b/ecommerce-backend/src/shared/middlewares.js
@@ -63,20 +63,6 @@ function rateLimit({ windowMs, limit }) {
   };
 }
 
-function csrfMiddleware(req, res, next) {
-  const method = req.method.toUpperCase();
-  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-    const tokenCookie = req.cookies && req.cookies.csrfToken;
-    const headerToken = req.headers['x-csrf-token'];
-    if (!tokenCookie || !headerToken || tokenCookie !== headerToken) {
-      return res
-        .status(403)
-        .json({ error: { code: ERROR_CODES[403], message: 'Invalid CSRF token' }, requestId: req.id });
-    }
-  }
-  next();
-}
-
 // Authorization middleware for role-based access control
 function requireRole(role) {
   return function (req, res, next) {
@@ -123,6 +109,5 @@ module.exports = {
   errorHandler,
   parseCookies,
   rateLimit,
-  csrfMiddleware,
   requireRole,
 };


### PR DESCRIPTION
## Summary
- drop unused CSRF middleware from shared utilities
- mark CSRF token cookie as HttpOnly and Secure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaeccf07a08323bd821aae53ad4307