### PR TITLE
feat: persist theme preference

### DIFF
--- a/ecommerce-frontend/src/components/ThemeToggle.js
+++ b/ecommerce-frontend/src/components/ThemeToggle.js
@@ -1,14 +1,11 @@
 import React, { useEffect, useState } from 'react';
 
 const ThemeToggle = () => {
-  const [theme, setTheme] = useState('light');
-
-  useEffect(() => {
-    const saved = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const initial = saved || (prefersDark ? 'dark' : 'light');
-    setTheme(initial);
-  }, []);
+  const [theme, setTheme] = useState(
+    () =>
+      localStorage.getItem('theme') ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  );
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);


### PR DESCRIPTION
## Summary
- initialize theme from localStorage or system preference
- remove redundant initialization effect and update theme attribute on change

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68aaecd9d39883238dfe1aa804f43d43