### PR TITLE
feat: smooth hero video edges

### DIFF
--- a/ecommerce-frontend/src/components/home/Hero.jsx
+++ b/ecommerce-frontend/src/components/home/Hero.jsx
@@ -31,6 +31,27 @@ function Hero({ title, subtitle, ctaHref = '/products' }) {
           background: 'linear-gradient(to bottom, rgba(0,0,0,0), var(--bs-body-bg))',
         }}
       />
+      <div
+        className="position-absolute top-0 start-0 w-100"
+        style={{
+          height: '20%',
+          background: 'linear-gradient(to bottom, var(--bs-body-bg), rgba(0,0,0,0))',
+        }}
+      />
+      <div
+        className="position-absolute top-0 start-0 h-100"
+        style={{
+          width: '20%',
+          background: 'linear-gradient(to right, var(--bs-body-bg), rgba(0,0,0,0))',
+        }}
+      />
+      <div
+        className="position-absolute top-0 end-0 h-100"
+        style={{
+          width: '20%',
+          background: 'linear-gradient(to left, var(--bs-body-bg), rgba(0,0,0,0))',
+        }}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add gradient overlays to top, left, and right edges of Hero video
- ensure video blends into background on all sides

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ab8b038414832387486c6c8b67f37a