### PR TITLE
feat(frontend): add add-to-cart button to product cards

### DIFF
--- a/ecommerce-backend/src/infra/models/index.js
+++ b/ecommerce-backend/src/infra/models/index.js
@@ -128,6 +128,9 @@ const Cart = sequelize.define('Cart', {
 // CartItem model
 const CartItem = sequelize.define('CartItem', {
   id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+  // Explicit FK fields so camelCase attributes map to snake_case columns
+  cartId: { type: DataTypes.INTEGER, allowNull: false, field: 'cart_id' },
+  productId: { type: DataTypes.INTEGER, allowNull: false, field: 'product_id' },
   quantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
   unitPrice: { type: DataTypes.DECIMAL(10,2), allowNull: false },
   subtotal: { type: DataTypes.DECIMAL(10,2) },
@@ -252,11 +255,11 @@ Product.belongsToMany(Category, { through: ProductCategory, as: 'categories' });
 Category.belongsToMany(Product, { through: ProductCategory, as: 'products' });
 
 // Cart relations
-Cart.hasMany(CartItem, { as: 'items' });
-CartItem.belongsTo(Cart);
+Cart.hasMany(CartItem, { as: 'items', foreignKey: 'cartId' });
+CartItem.belongsTo(Cart, { foreignKey: 'cartId' });
 
-Product.hasMany(CartItem, { as: 'cartItems' });
-CartItem.belongsTo(Product);
+Product.hasMany(CartItem, { as: 'cartItems', foreignKey: 'productId' });
+CartItem.belongsTo(Product, { foreignKey: 'productId' });
 
 // Order relations
 Order.hasMany(OrderItem, { as: 'items' });

--- a/ecommerce-frontend/src/components/ProductCard.js
+++ b/ecommerce-frontend/src/components/ProductCard.js
@@ -1,9 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import BrickButton from './lego/BrickButton';
+import * as api from '../services/api';
 
 // Card component for displaying a product in a grid. Uses Bootstrap classes.
 function ProductCard({ product }) {
+  const [added, setAdded] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleAddToCart = async () => {
+    try {
+      setLoading(true);
+      await api.addToCart({ productId: product.id, quantity: 1 });
+      setAdded(true);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="col-md-4 col-sm-6 mb-4" role="listitem">
       <div className="card h-100 brick-card" role="article" aria-label={product.name}>
@@ -16,9 +33,19 @@ function ProductCard({ product }) {
             {product.description && product.description.length > 80 ? '…' : ''}
           </p>
           <p className="card-text fw-bold">${parseFloat(product.price).toFixed(2)}</p>
-          <Link to={`/products/${product.id}`} className="mt-auto text-decoration-none">
-            <BrickButton className="w-100">Ver</BrickButton>
-          </Link>
+          <div className="mt-auto">
+            <BrickButton
+              className="w-100 mb-2"
+              color={added ? 'green' : 'yellow'}
+              onClick={handleAddToCart}
+              disabled={loading}
+            >
+              {added ? '✔ Añadido' : loading ? 'Añadiendo…' : 'Añadir al carrito'}
+            </BrickButton>
+            <Link to={`/products/${product.id}`} className="text-decoration-none">
+              <BrickButton className="w-100">Ver</BrickButton>
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/ecommerce-frontend/src/theme/lego.css
+++ b/ecommerce-frontend/src/theme/lego.css
@@ -41,6 +41,8 @@ body.no-texture .card.brick-card .card-body.tex{ background-image:none; }
   transform:translateY(0);
   transition:transform 80ms, box-shadow 80ms, filter .2s;
 }
+.btn-brick:hover,
+.btn-brick:focus{ filter:brightness(1.1); }
 .btn-brick:active{
   transform:translateY(.25rem);
   box-shadow: inset 0 .05rem 0 rgba(255,255,255,.2),
@@ -50,6 +52,7 @@ body.no-texture .card.brick-card .card-body.tex{ background-image:none; }
 .btn-brick.yellow{ --bg:var(--bs-warning); color:#111; }
 .btn-brick.blue  { --bg:var(--bs-info); }
 .btn-brick.red   { --bg:var(--bs-danger); }
+.btn-brick.green { --bg:var(--bs-success); }
 
 /* Card tipo placa */
 .card.brick-card{


### PR DESCRIPTION
## Summary
- add prominent add-to-cart button in product cards with success feedback
- brighten LEGO-styled buttons on hover and include green variation

## Testing
- `npm test -- --watchAll=false`

