### PR TITLE
feat: unify product and category image styling

### DIFF
--- a/ecommerce-frontend/src/components/home/CategoryCarousel.jsx
+++ b/ecommerce-frontend/src/components/home/CategoryCarousel.jsx
@@ -34,13 +34,8 @@ function CategoryCarousel() {
                     to={`/products?theme=${encodeURIComponent(cat.theme)}`}
                     className="text-decoration-none"
                   >
-                    <div className="position-relative">
-                      <img
-                        src={cat.image}
-                        alt={cat.name}
-                        className="d-block w-100 rounded"
-                        loading="lazy"
-                      />
+                    <div className="image-frame">
+                      <img src={cat.image} alt={cat.name} loading="lazy" />
                     </div>
                   </Link>
                 </div>

--- a/ecommerce-frontend/src/components/home/ProductCarousel.jsx
+++ b/ecommerce-frontend/src/components/home/ProductCarousel.jsx
@@ -52,15 +52,11 @@ function ProductCarousel() {
         {products.map((p, idx) => (
           <div className={`carousel-item ${idx === 0 ? 'active' : ''}`} key={p.id}>
             {p.image ? (
-              <img
-                src={p.image}
-                className="d-block w-100"
-                style={{ height: '400px', objectFit: 'cover' }}
-                alt={p.name}
-                loading="lazy"
-              />
+              <div className="image-frame" style={{ height: '400px' }}>
+                <img src={p.image} alt={p.name} loading="lazy" />
+              </div>
             ) : (
-              <div className="bg-secondary" style={{ height: '300px' }} />
+              <div className="image-frame bg-secondary" style={{ height: '300px' }} />
             )}
             <div className="carousel-caption d-none d-md-block">
               <h5>{p.name}</h5>

--- a/ecommerce-frontend/src/theme/lego.css
+++ b/ecommerce-frontend/src/theme/lego.css
@@ -87,3 +87,20 @@ footer a.text-light{ color:#f8f9fa; text-decoration:none; }
 footer a.text-light:hover{ color:var(--bs-danger); }
 .footer-social a{ color:#fff; font-size:1.25rem; transition:color .15s; }
 .footer-social a:hover{ color:var(--bs-danger); }
+
+/* Marco y estilos neutrales para imágenes de productos o categorías */
+.image-frame{
+  border-radius:.25rem;
+  padding:.25rem;
+  background-color:#fff;
+  overflow:hidden;
+}
+.image-frame img{
+  display:block;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  background-color:#f8f9fa;
+  box-shadow:none;
+  border-radius:.25rem;
+}


### PR DESCRIPTION
## Summary
- ensure category carousel images sit within neutral framed container
- wrap featured product images with border-matching frame and neutral background
- add reusable CSS class for image frames to keep product visuals flat

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68abfe838c64832394c860a608110f9a