### PR TITLE
feat: highlight new and sale products

### DIFF
--- a/ecommerce-backend/src/graphql/typeDefs.js
+++ b/ecommerce-backend/src/graphql/typeDefs.js
@@ -37,6 +37,8 @@ const typeDefs = gql`
     price: Float!
     currency: String
     image: String
+    isNew: Boolean
+    isOnSale: Boolean
     status: String
     stock: Int!
     categories: [Category!]

--- a/ecommerce-backend/src/infra/migrations/001_init.sql
+++ b/ecommerce-backend/src/infra/migrations/001_init.sql
@@ -28,6 +28,9 @@ CREATE TABLE products (
   description TEXT,
   price REAL NOT NULL,
   currency TEXT NOT NULL,
+  image TEXT,
+  is_new INTEGER NOT NULL DEFAULT 0,
+  is_on_sale INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'active',
   stock INTEGER NOT NULL DEFAULT 0 CHECK (stock >= 0)
 );

--- a/ecommerce-backend/src/infra/models/index.js
+++ b/ecommerce-backend/src/infra/models/index.js
@@ -86,6 +86,8 @@ const Product = sequelize.define('Product', {
   price: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
   currency: { type: DataTypes.STRING(3), allowNull: false },
   image: { type: DataTypes.STRING },
+  isNew: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  isOnSale: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'active' },
   stock: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
 }, {

--- a/ecommerce-backend/src/infra/seeds/seed.js
+++ b/ecommerce-backend/src/infra/seeds/seed.js
@@ -22,6 +22,7 @@ async function seed() {
       stock: 5,
       categories: ['Star Wars'],
       images: ['https://picsum.photos/seed/lego-millennium-falcon/600/400'],
+      isNew: true,
     },
     {
       code: 'TECH001',
@@ -32,6 +33,7 @@ async function seed() {
       stock: 10,
       categories: ['Technic'],
       images: ['https://picsum.photos/seed/lego-bugatti/600/400'],
+      isOnSale: true,
     },
     {
       code: 'CITY001',
@@ -42,6 +44,7 @@ async function seed() {
       stock: 20,
       categories: ['City'],
       images: ['https://picsum.photos/seed/lego-police-station/600/400'],
+      isNew: true,
     },
     {
       code: 'IDEA001',
@@ -62,6 +65,7 @@ async function seed() {
       stock: 8,
       categories: ['Harry Potter'],
       images: ['https://picsum.photos/seed/lego-hogwarts/600/400'],
+      isOnSale: true,
     },
     {
       code: 'CRE001',
@@ -95,6 +99,8 @@ async function seed() {
       currency: set.currency,
       stock: set.stock,
       image: set.images[0],
+      isNew: !!set.isNew,
+      isOnSale: !!set.isOnSale,
     });
 
     const cats = set.categories.map((name) => categories[name]).filter(Boolean);

--- a/ecommerce-frontend/src/components/ProductCard.js
+++ b/ecommerce-frontend/src/components/ProductCard.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import BrickButton from "./lego/BrickButton";
+import BrickBadge from "./lego/BrickBadge";
 import * as api from "../services/api";
 import "./ProductCard.css";
 
@@ -30,10 +31,26 @@ function ProductCard({ product }) {
   return (
     <div className="col-md-4 col-sm-6 mb-4" role="listitem">
       <div
-        className="card h-100 brick-card"
+        className="card h-100 brick-card position-relative"
         role="article"
         aria-label={product.name}
       >
+        {product.isNew && (
+          <BrickBadge
+            color="lego-yellow"
+            className="position-absolute top-0 start-0 m-2"
+          >
+            Nuevo
+          </BrickBadge>
+        )}
+        {product.isOnSale && (
+          <BrickBadge
+            color="lego-red"
+            className="position-absolute top-0 end-0 m-2"
+          >
+            Oferta
+          </BrickBadge>
+        )}
         <div
           className="card-img-top bg-secondary"
           style={{ height: "180px" }}

--- a/ecommerce-frontend/src/theme/lego.css
+++ b/ecommerce-frontend/src/theme/lego.css
@@ -87,6 +87,9 @@ body.no-texture .card.brick-card .card-body.tex{ background-image:none; }
   box-shadow: inset 0 .05rem 0 rgba(255,255,255,.25);
 }
 
+.bg-lego-yellow{ background-color:#FFCF00!important; color:#000; }
+.bg-lego-red{ background-color:#DA291C!important; color:#fff; }
+
 /* Enlaces del footer */
 footer a.text-light{ color:#f8f9fa; text-decoration:none; }
 footer a.text-light:hover{ color:var(--bs-danger); }


### PR DESCRIPTION
## Summary
- add `isNew` and `isOnSale` fields to products
- display LEGO-colored badges for new and sale items
- expose new flags via GraphQL and seed sample data

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ac07b0fd2083239c227fe32c3d34fe