### PR TITLE
refactor: unify product image field

### DIFF
--- a/ecommerce-backend/src/graphql/typeDefs.js
+++ b/ecommerce-backend/src/graphql/typeDefs.js
@@ -36,7 +36,7 @@ const typeDefs = gql`
     description: String
     price: Float!
     currency: String
-    image: String
+    imageUrl: String
     isNew: Boolean
     isOnSale: Boolean
     status: String

--- a/ecommerce-backend/src/infra/migrations/001_init.sql
+++ b/ecommerce-backend/src/infra/migrations/001_init.sql
@@ -28,7 +28,7 @@ CREATE TABLE products (
   description TEXT,
   price REAL NOT NULL,
   currency TEXT NOT NULL,
-  image TEXT,
+  image_url TEXT,
   is_new INTEGER NOT NULL DEFAULT 0,
   is_on_sale INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'active',

--- a/ecommerce-backend/src/infra/models/index.js
+++ b/ecommerce-backend/src/infra/models/index.js
@@ -85,7 +85,7 @@ const Product = sequelize.define('Product', {
   description: { type: DataTypes.TEXT },
   price: { type: DataTypes.DECIMAL(10, 2), allowNull: false },
   currency: { type: DataTypes.STRING(3), allowNull: false },
-  image: { type: DataTypes.STRING },
+  imageUrl: { type: DataTypes.STRING },
   isNew: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   isOnSale: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'active' },

--- a/ecommerce-backend/src/infra/seeds/seed.js
+++ b/ecommerce-backend/src/infra/seeds/seed.js
@@ -98,7 +98,7 @@ async function seed() {
       price: set.price.toFixed(2),
       currency: set.currency,
       stock: set.stock,
-      image: set.images[0],
+      imageUrl: set.images[0],
       isNew: !!set.isNew,
       isOnSale: !!set.isOnSale,
     });

--- a/ecommerce-backend/src/modules/cart/controller.js
+++ b/ecommerce-backend/src/modules/cart/controller.js
@@ -12,8 +12,9 @@ function attachTotal(cart) {
 
   // Map items to only expose required fields and avoid leaking the Product model
   const items = (data.items || []).map((it) => ({
+    id: it.id,
     name: it.Product ? it.Product.name : undefined,
-    thumbnailUrl: it.Product ? it.Product.image : undefined,
+    imageUrl: it.Product ? it.Product.imageUrl : undefined,
     unitPrice: parseFloat(it.unitPrice),
     quantity: it.quantity,
   }));

--- a/ecommerce-backend/test/cartController.test.js
+++ b/ecommerce-backend/test/cartController.test.js
@@ -88,9 +88,10 @@ test('removeItem deletes an item from the cart', async () => {
 // Obtener carrito con estructura simplificada de ítems
 test('getCart returns items with expected shape', async () => {
   const item = {
+    id: 42,
     quantity: 3,
     unitPrice: '5.00',
-    Product: { name: 'Brick', image: 'brick.png' },
+    Product: { name: 'Brick', imageUrl: 'brick.png' },
   };
   mockModels.Cart.findOne = async () => ({
     toJSON() {
@@ -104,10 +105,13 @@ test('getCart returns items with expected shape', async () => {
   await getCart(req, res, (err) => { if (err) throw err; });
 
   assert.deepStrictEqual(output.items, [
-    { name: 'Brick', thumbnailUrl: 'brick.png', unitPrice: 5, quantity: 3 },
+    { id: 42, name: 'Brick', imageUrl: 'brick.png', unitPrice: 5, quantity: 3 },
   ]);
   assert.strictEqual(output.total, 15);
   // Ensure no extra properties like Product are leaked
-  assert.deepStrictEqual(Object.keys(output.items[0]).sort(), ['name', 'quantity', 'thumbnailUrl', 'unitPrice'].sort());
+  assert.deepStrictEqual(
+    Object.keys(output.items[0]).sort(),
+    ['id', 'imageUrl', 'name', 'quantity', 'unitPrice'].sort()
+  );
 });
 

--- a/ecommerce-frontend/src/components/MiniCart.js
+++ b/ecommerce-frontend/src/components/MiniCart.js
@@ -20,15 +20,15 @@ function MiniCart() {
           role="menuitem"
         >
           <img
-            src={item.product?.image}
-            alt={item.product?.name}
+            src={item.imageUrl}
+            alt={item.name}
             width="40"
             height="40"
             className="flex-shrink-0"
             style={{ objectFit: 'cover' }}
           />
           <div className="flex-grow-1">
-            <div>{item.product?.name}</div>
+            <div>{item.name}</div>
             <div className="small text-muted">
               ${parseFloat(item.unitPrice).toFixed(2)} c/u
             </div>

--- a/ecommerce-frontend/src/components/ProductCard.js
+++ b/ecommerce-frontend/src/components/ProductCard.js
@@ -53,10 +53,19 @@ function ProductCard({ product }) {
             Oferta
           </BrickBadge>
         )}
-        <div
-          className="card-img-top bg-secondary"
-          style={{ height: "180px" }}
-        ></div>
+        {product.imageUrl ? (
+          <img
+            src={product.imageUrl}
+            alt={product.name}
+            className="card-img-top"
+            style={{ objectFit: "cover", height: "180px" }}
+          />
+        ) : (
+          <div
+            className="card-img-top bg-secondary"
+            style={{ height: "180px" }}
+          ></div>
+        )}
         <div className="card-body d-flex flex-column">
           <h5 className="card-title">{product.name}</h5>
           <p className="card-text flex-grow-1">

--- a/ecommerce-frontend/src/components/home/ProductCarousel.jsx
+++ b/ecommerce-frontend/src/components/home/ProductCarousel.jsx
@@ -51,9 +51,9 @@ function ProductCarousel() {
       <div className="carousel-inner">
         {products.map((p, idx) => (
           <div className={`carousel-item ${idx === 0 ? 'active' : ''}`} key={p.id}>
-            {p.image ? (
+            {p.imageUrl ? (
               <div className="image-frame" style={{ height: '400px' }}>
-                <img src={p.image} alt={p.name} loading="lazy" />
+                <img src={p.imageUrl} alt={p.name} loading="lazy" />
               </div>
             ) : (
               <div className="image-frame bg-secondary" style={{ height: '300px' }} />

--- a/ecommerce-frontend/src/pages/CartPage.js
+++ b/ecommerce-frontend/src/pages/CartPage.js
@@ -82,13 +82,9 @@ function CartPage() {
               {cart.items.map((item) => (
                 <tr key={item.id}>
                   <td>
-                    <img
-                      src={item.product?.image}
-                      alt={item.product?.name}
-                      width="60"
-                    />
+                    <img src={item.imageUrl} alt={item.name} width="60" />
                   </td>
-                  <td>{item.product?.name}</td>
+                  <td>{item.name}</td>
                   <td>
                     <QuantityStepper
                       value={item.quantity}


### PR DESCRIPTION
## Summary
- use `imageUrl` for Product model and seeds
- expose `imageUrl` in cart items and frontend components
- rename product image references across GraphQL, migrations, and tests

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ac98366ac88323a03de2a1c76bafe6