### PR TITLE
feat: persist redirect across google login

### DIFF
--- a/ecommerce-frontend/src/pages/LoginCallback.jsx
+++ b/ecommerce-frontend/src/pages/LoginCallback.jsx
@@ -11,7 +11,9 @@ const LoginCallback = () => {
     const params = new URLSearchParams(search);
     const ok = params.get('ok');
     if (ok) {
-      fetchMe().finally(() => navigate('/'));
+      const redirectTo = sessionStorage.getItem('redirectTo');
+      sessionStorage.removeItem('redirectTo');
+      fetchMe().finally(() => navigate(redirectTo || -1));
     } else {
       navigate('/login');
     }

--- a/ecommerce-frontend/src/pages/LoginPage.jsx
+++ b/ecommerce-frontend/src/pages/LoginPage.jsx
@@ -81,7 +81,14 @@ const LoginPage = () => {
       <hr />
       <button
         className="btn btn-outline-secondary w-100 d-flex align-items-center justify-content-center"
-        onClick={loginWithGoogle}
+        onClick={() => {
+          if (redirectTo) {
+            sessionStorage.setItem('redirectTo', redirectTo);
+          } else {
+            sessionStorage.removeItem('redirectTo');
+          }
+          loginWithGoogle();
+        }}
         aria-label="Continuar con Google"
       >
         <i className="fa-brands fa-google me-2" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- store redirect path in session storage before starting Google login
- redirect to stored path after OAuth callback

## Testing
- `cd ecommerce-frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68acac3e7b508323b19cf950c550de71