### PR TITLE
feat: improve cart modal accessibility

### DIFF
--- a/ecommerce-frontend/src/components/CartModal.jsx
+++ b/ecommerce-frontend/src/components/CartModal.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useCart } from '../contexts/CartContext';
 import MiniCart from './MiniCart';
 import BrickModal from './lego/BrickModal';
 
 // Modal displaying current cart items with actions.
 export default function CartModal() {
+  const navigate = useNavigate();
   const { cart } = useCart();
   const items = cart?.items || [];
   const itemsCount = cart?.summary?.itemsCount || 0;
@@ -14,24 +15,42 @@ export default function CartModal() {
     0,
   );
 
+  const closeAndNavigate = (path) => {
+    const modalEl = document.getElementById('cartModal');
+    if (modalEl && window.bootstrap?.Modal) {
+      const instance = window.bootstrap.Modal.getInstance(modalEl) ||
+        new window.bootstrap.Modal(modalEl);
+      instance.hide();
+    }
+    navigate(path);
+  };
+
   return (
     <BrickModal id="cartModal" title="Tu Carrito">
       {itemsCount ? (
         <>
           <MiniCart />
           <div className="mt-3 d-flex justify-content-between align-items-center">
-            <Link to="/cart" className="btn btn-outline-primary">
-              Ver carrito
-            </Link>
-            <span className="fw-bold">Total: ${total.toFixed(2)}</span>
-          </div>
-          <div className="mt-3 d-flex justify-content-end gap-2">
-            <Link to="/checkout" className="btn btn-danger">
-              Proceder al pago
-            </Link>
             <button
               type="button"
               className="btn btn-outline-secondary"
+              onClick={() => closeAndNavigate('/cart')}
+            >
+              Ver carrito
+            </button>
+            <span className="fw-bold">Total: ${total.toFixed(2)}</span>
+          </div>
+          <div className="mt-3 d-flex justify-content-end gap-2">
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => closeAndNavigate('/checkout')}
+            >
+              Proceder al pago
+            </button>
+            <button
+              type="button"
+              className="btn btn-warning"
               data-bs-dismiss="modal"
             >
               Seguir comprando

--- a/ecommerce-frontend/src/components/MiniCart.js
+++ b/ecommerce-frontend/src/components/MiniCart.js
@@ -20,15 +20,15 @@ function MiniCart() {
           role="menuitem"
         >
           <img
-            src={item.imageUrl}
-            alt={item.name}
-            width="40"
-            height="40"
-            className="flex-shrink-0"
+            src={item.imageUrl || 'https://via.placeholder.com/64'}
+            alt={item.displayName || item.name}
+            width="64"
+            height="64"
+            className="flex-shrink-0 rounded"
             style={{ objectFit: 'cover' }}
           />
           <div className="flex-grow-1">
-            <div>{item.name}</div>
+            <div>{item.displayName || item.name}</div>
             <div className="small text-muted">
               ${parseFloat(item.unitPrice).toFixed(2)} c/u
             </div>

--- a/ecommerce-frontend/src/components/lego/BrickModal.jsx
+++ b/ecommerce-frontend/src/components/lego/BrickModal.jsx
@@ -6,7 +6,7 @@ export default function BrickModal({ id, title, children }) {
   return (
     <div className="modal fade" id={id} tabIndex="-1" aria-hidden="true">
       <div className="modal-dialog modal-dialog-centered">
-        <div className="modal-content brick-modal">
+        <div className="modal-content brick-modal bg-body text-body">
           <div className="modal-header border-0">
             <h5 className="modal-title fw-bold d-flex align-items-center">
               <i className="fa-solid fa-cube me-2 text-warning" aria-hidden="true"></i>

--- a/ecommerce-frontend/src/theme/lego.css
+++ b/ecommerce-frontend/src/theme/lego.css
@@ -72,12 +72,10 @@ body.no-texture .card.brick-card .card-body.tex{ background-image:none; }
 
 /* Modal general */
 .modal-content.brick-modal{
-  background:#fff;
   border-radius:.375rem;
-  border:1px solid rgba(0,0,0,.1);
+  border:1px solid var(--bs-border-color);
   box-shadow:0 .5rem 1rem rgba(0,0,0,.15);
 }
-.brick-modal .modal-title{ color:#000; }
 .modal-backdrop.show{ opacity:.5; }
 
 /* Badge tile */


### PR DESCRIPTION
## Summary
- support dark mode in cart modal
- show item thumbnails and placeholders in mini cart
- ensure modal closes when navigating to cart or checkout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb7daacac8323869db3a6201a08b8