### PR TITLE
feat: enhance newsletter signup with tagline and privacy note

### DIFF
--- a/ecommerce-frontend/src/components/home/Newsletter.jsx
+++ b/ecommerce-frontend/src/components/home/Newsletter.jsx
@@ -21,27 +21,33 @@ function Newsletter() {
   };
 
   return (
-    <form className="row g-3" onSubmit={handleSubmit} noValidate>
-      <div className="col-md-6 mx-auto">
-        <label htmlFor="newsletter-email" className="form-label">
-          Suscríbete a nuestras novedades
-        </label>
-        <div className="input-group">
-          <input
-            type="email"
-            id="newsletter-email"
-            className="form-control"
-            placeholder="email@ejemplo.com"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <button className="btn btn-primary" type="submit" disabled={loading}>
-            Enviar
-          </button>
+    <div className="lego-container">
+      <form className="row g-3" onSubmit={handleSubmit} noValidate>
+        <div className="col-md-6 mx-auto">
+          <label htmlFor="newsletter-email" className="form-label">
+            Suscríbete a nuestras novedades
+          </label>
+          <p className="text-muted">Recibe promociones exclusivas y novedades</p>
+          <div className="input-group">
+            <input
+              type="email"
+              id="newsletter-email"
+              className="form-control"
+              placeholder="email@ejemplo.com"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <button className="btn btn-primary" type="submit" disabled={loading}>
+              Enviar
+            </button>
+          </div>
+          <small className="text-muted">
+            <span role="img" aria-label="lock">🔒</span> Nunca compartiremos tu email.
+          </small>
         </div>
-      </div>
-    </form>
+      </form>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add promotional tagline and privacy note to newsletter signup
- wrap newsletter section with `lego-container` for layout consistency

## Testing
- `npm test --prefix ecommerce-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68ad993242b0832385a5cd6b9c428284