### PR TITLE
feat: add advanced catalog filters and facets

### DIFF
--- a/ecommerce-backend/src/modules/catalog/dto.js
+++ b/ecommerce-backend/src/modules/catalog/dto.js
@@ -1,11 +1,41 @@
 // Data transfer objects and validation for catalog module
 const { ApiError } = require('../../shared/errors');
 
+// Helper to parse boolean query params
+function parseBoolean(value, name) {
+  if (value === undefined) return undefined;
+  if (value === 'true' || value === '1' || value === true) return true;
+  if (value === 'false' || value === '0' || value === false) return false;
+  throw new ApiError(`${name} must be boolean`, 400);
+}
+
 function parseGetProducts(query) {
-  const { search, theme, minPrice, maxPrice, page, limit, order } = query;
+  const {
+    search,
+    theme,
+    minPrice,
+    maxPrice,
+    page,
+    limit,
+    order,
+    slug,
+    setNumber,
+    minPieces,
+    maxPieces,
+    ageMin,
+    ageMax,
+    status,
+    visibility,
+    isOnSale,
+    isNew,
+  } = query;
   const result = {};
+
   if (search !== undefined) result.search = String(search);
   if (theme !== undefined) result.theme = String(theme);
+  if (slug !== undefined) result.slug = String(slug);
+  if (setNumber !== undefined) result.setNumber = String(setNumber);
+
   if (minPrice !== undefined) {
     const value = parseFloat(minPrice);
     if (isNaN(value)) throw new ApiError('minPrice must be a number', 400);
@@ -16,6 +46,29 @@ function parseGetProducts(query) {
     if (isNaN(value)) throw new ApiError('maxPrice must be a number', 400);
     result.maxPrice = value;
   }
+
+  if (minPieces !== undefined) {
+    const value = parseInt(minPieces, 10);
+    if (isNaN(value) || value < 0) throw new ApiError('minPieces must be a non-negative integer', 400);
+    result.minPieces = value;
+  }
+  if (maxPieces !== undefined) {
+    const value = parseInt(maxPieces, 10);
+    if (isNaN(value) || value < 0) throw new ApiError('maxPieces must be a non-negative integer', 400);
+    result.maxPieces = value;
+  }
+
+  if (ageMin !== undefined) {
+    const value = parseInt(ageMin, 10);
+    if (isNaN(value) || value < 0) throw new ApiError('ageMin must be a non-negative integer', 400);
+    result.ageMin = value;
+  }
+  if (ageMax !== undefined) {
+    const value = parseInt(ageMax, 10);
+    if (isNaN(value) || value < 0) throw new ApiError('ageMax must be a non-negative integer', 400);
+    result.ageMax = value;
+  }
+
   if (page !== undefined) {
     const value = parseInt(page, 10);
     if (isNaN(value) || value < 1) throw new ApiError('page must be positive integer', 400);
@@ -26,7 +79,16 @@ function parseGetProducts(query) {
     if (isNaN(value) || value < 1) throw new ApiError('limit must be positive integer', 400);
     result.limit = value;
   }
+
+  if (status !== undefined) result.status = String(status);
+  if (visibility !== undefined) result.visibility = String(visibility);
   if (order !== undefined) result.order = String(order);
+
+  const onSale = parseBoolean(isOnSale, 'isOnSale');
+  if (onSale !== undefined) result.isOnSale = onSale;
+  const newFlag = parseBoolean(isNew, 'isNew');
+  if (newFlag !== undefined) result.isNew = newFlag;
+
   return result;
 }
 

--- a/ecommerce-backend/test/productsController.test.js
+++ b/ecommerce-backend/test/productsController.test.js
@@ -35,12 +35,17 @@ test('getProducts applies filters, pagination and ordering', async () => {
   const res = { json: (data) => { output = data; } };
   await getProducts(req, res, (err) => { if (err) throw err; });
 
-  assert.deepStrictEqual(output, {
-    total: 1,
-    limit: 5,
-    page: 2,
-    items: [{ id: 1, name: 'Mock', price: 150 }],
-  });
+  assert.strictEqual(output.total, 1);
+  assert.strictEqual(output.limit, 5);
+  assert.strictEqual(output.page, 2);
+  assert.ok(Array.isArray(output.items));
+  assert.strictEqual(output.items.length, 1);
+  assert.strictEqual(output.items[0].id, 1);
+  assert.strictEqual(output.items[0].name, 'Mock');
+  assert.strictEqual(output.items[0].salePrice, 150);
+  assert.strictEqual(output.items[0].priceEffective, 150);
+  assert.strictEqual(output.items[0].isOnSale, false);
+  assert.ok(output.facets);
 
   assert.strictEqual(Product.lastArgs.limit, 5);
   assert.strictEqual(Product.lastArgs.offset, 5);


### PR DESCRIPTION
## Summary
- expand catalog DTO to support slug, setNumber, piece count, age, status, visibility, sale, new filters
- apply advanced filters, ordering, derived price fields and facets in catalog controller
- allow product lookup by slug or id

## Testing
- `npm test --prefix ecommerce-backend`

------
https://chatgpt.com/codex/tasks/task_e_68ae7c7685288323ae46c1d33c31b8d4