### PR TITLE
Derive cart pricing from products and enforce limits

### DIFF
--- a/ecommerce-backend/src/infra/models/index.js
+++ b/ecommerce-backend/src/infra/models/index.js
@@ -107,6 +107,7 @@ const Product = sequelize.define('Product', {
   isOnSale: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'active' },
   stock: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  maxQtyPerOrder: { type: DataTypes.INTEGER, field: 'max_qty_per_order' },
 }, {
   tableName: 'products',
   underscored: true,
@@ -155,6 +156,8 @@ const CartItem = sequelize.define('CartItem', {
   quantity: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
   unitPrice: { type: DataTypes.DECIMAL(10,2), allowNull: false },
   subtotal: { type: DataTypes.DECIMAL(10,2) },
+  displayName: { type: DataTypes.STRING, field: 'display_name' },
+  thumbnailUrl: { type: DataTypes.STRING, field: 'thumbnail_url' },
 }, {
   tableName: 'cart_items',
   underscored: true,

--- a/ecommerce-backend/src/modules/cart/controller.js
+++ b/ecommerce-backend/src/modules/cart/controller.js
@@ -5,16 +5,23 @@
 const { Cart, CartItem, Product } = require('../../infra/models');
 const { ApiError } = require('../../shared/errors');
 
+// Determine a product's effective unit price based on sale price vs MSRP
+function getEffectivePrice(product) {
+  const salePrice = product.price != null ? parseFloat(product.price) : null;
+  const msrp = product.msrp != null ? parseFloat(product.msrp) : null;
+  return salePrice != null ? salePrice : msrp;
+}
+
 // Helper to attach cart total and expose a simplified item structure
 function attachTotal(cart) {
   if (!cart) return null;
   const data = cart.toJSON();
 
-  // Map items to only expose required fields and avoid leaking the Product model
+  // Map items to only expose required fields
   const items = (data.items || []).map((it) => ({
     id: it.id,
-    name: it.Product ? it.Product.name : undefined,
-    imageUrl: it.Product ? it.Product.imageUrl : undefined,
+    displayName: it.displayName,
+    thumbnailUrl: it.thumbnailUrl,
     unitPrice: parseFloat(it.unitPrice),
     quantity: it.quantity,
   }));
@@ -33,7 +40,7 @@ exports.getCart = async (req, res, next) => {
     if (!user) throw new ApiError('Not authenticated', 401);
     const cart = await Cart.findOne({
       where: { userId: user.id },
-      include: { model: CartItem, as: 'items', include: [Product] },
+      include: { model: CartItem, as: 'items' },
     });
     res.json(attachTotal(cart));
   } catch (err) {
@@ -50,22 +57,29 @@ exports.addItem = async (req, res, next) => {
     const { productId, quantity } = dto.parseAddItem(req.body);
     const product = await Product.findByPk(productId);
     if (!product) throw new ApiError('Product not found', 404);
+    if (product.status === 'discontinued') throw new ApiError('Product discontinued', 400);
     const [cart] = await Cart.findOrCreate({
       where: { userId: user.id },
       defaults: {},
     });
     const [item] = await CartItem.findOrCreate({
       where: { cartId: cart.id, productId: product.id },
-      defaults: { quantity: 0, unitPrice: product.price },
+      defaults: { quantity: 0, unitPrice: 0 },
     });
     const newQty = item.quantity + parseInt(quantity, 10);
+    if (product.maxQtyPerOrder && newQty > product.maxQtyPerOrder) {
+      throw new ApiError('Exceeds max qty per order', 400);
+    }
     if (newQty > product.stock) throw new ApiError('Insufficient stock', 400);
+    const price = getEffectivePrice(product);
     item.quantity = newQty;
-    item.unitPrice = product.price;
+    item.unitPrice = price;
+    item.displayName = product.name;
+    item.thumbnailUrl = product.imageUrl;
     item.subtotal = item.quantity * item.unitPrice;
     await item.save();
     const refreshed = await Cart.findByPk(cart.id, {
-      include: { model: CartItem, as: 'items', include: [Product] },
+      include: { model: CartItem, as: 'items' },
     });
     res.json(attachTotal(refreshed));
   } catch (err) {
@@ -93,16 +107,23 @@ exports.updateItem = async (req, res, next) => {
     } else {
       const product = await Product.findByPk(item.productId);
       if (!product) throw new ApiError('Product not found', 404);
+      if (product.status === 'discontinued') throw new ApiError('Product discontinued', 400);
       const newQty = parseInt(quantity, 10);
+      if (product.maxQtyPerOrder && newQty > product.maxQtyPerOrder) {
+        throw new ApiError('Exceeds max qty per order', 400);
+      }
       if (newQty > product.stock) throw new ApiError('Insufficient stock', 400);
+      const price = getEffectivePrice(product);
       item.quantity = newQty;
-      item.unitPrice = product.price;
+      item.unitPrice = price;
+      item.displayName = product.name;
+      item.thumbnailUrl = product.imageUrl;
       item.subtotal = item.quantity * item.unitPrice;
       await item.save();
     }
     const cart = await Cart.findOne({
       where: { id: item.cartId, userId: user.id },
-      include: { model: CartItem, as: 'items', include: [Product] },
+      include: { model: CartItem, as: 'items' },
     });
     res.json(attachTotal(cart));
   } catch (err) {
@@ -126,7 +147,7 @@ exports.removeItem = async (req, res, next) => {
     await item.destroy();
     const cart = await Cart.findOne({
       where: { id: cartId, userId: user.id },
-      include: { model: CartItem, as: 'items', include: [Product] },
+      include: { model: CartItem, as: 'items' },
     });
     res.json(attachTotal(cart));
   } catch (err) {
@@ -145,7 +166,7 @@ exports.clearCart = async (req, res, next) => {
     });
     await CartItem.destroy({ where: { cartId: cart.id } });
     const refreshed = await Cart.findByPk(cart.id, {
-      include: { model: CartItem, as: 'items', include: [Product] },
+      include: { model: CartItem, as: 'items' },
     });
     res.json(attachTotal(refreshed));
   } catch (err) {

--- a/ecommerce-backend/test/cartController.test.js
+++ b/ecommerce-backend/test/cartController.test.js
@@ -12,8 +12,8 @@ const { ApiError } = require('../src/shared/errors');
 
 // Añadir artículo nuevo al carrito
 test('addItem adds a new product to the cart', async () => {
-  const item = { quantity: 0, unitPrice: 0, subtotal: 0, save: async function(){ return this; }, cartId: 1, productId: 1 };
-  mockModels.Product.findByPk = async () => ({ id: 1, price: 10, stock: 5 });
+  const item = { quantity: 0, unitPrice: 0, subtotal: 0, displayName: '', thumbnailUrl: '', save: async function(){ return this; }, cartId: 1, productId: 1 };
+  mockModels.Product.findByPk = async () => ({ id: 1, price: 8, msrp: 10, stock: 5, name: 'Brick', imageUrl: 'brick.png', status: 'active' });
   mockModels.Cart.findOrCreate = async () => [{ id: 1 }];
   mockModels.CartItem.findOrCreate = async () => [item];
   mockModels.Cart.findByPk = async () => ({
@@ -28,14 +28,17 @@ test('addItem adds a new product to the cart', async () => {
   await addItem(req, res, (err) => { if (err) throw err; });
 
   assert.strictEqual(item.quantity, 2);
-  assert.strictEqual(item.subtotal, 20);
-  assert.strictEqual(output.total, 20);
+  assert.strictEqual(item.unitPrice, 8);
+  assert.strictEqual(item.displayName, 'Brick');
+  assert.strictEqual(item.thumbnailUrl, 'brick.png');
+  assert.strictEqual(item.subtotal, 16);
+  assert.strictEqual(output.total, 16);
 });
 
 // Incrementar cantidad cuando el artículo ya existe en el carrito
 test('addItem increments quantity for an existing item', async () => {
-  const item = { quantity: 2, unitPrice: 10, subtotal: 20, save: async function(){ return this; }, cartId: 1, productId: 1 };
-  mockModels.Product.findByPk = async () => ({ id: 1, price: 10, stock: 10 });
+  const item = { quantity: 2, unitPrice: 10, subtotal: 20, displayName: 'Brick', thumbnailUrl: 'brick.png', save: async function(){ return this; }, cartId: 1, productId: 1 };
+  mockModels.Product.findByPk = async () => ({ id: 1, price: 10, msrp: 12, stock: 10, name: 'Brick', imageUrl: 'brick.png', status: 'active' });
   mockModels.Cart.findOrCreate = async () => [{ id: 1 }];
   mockModels.CartItem.findOrCreate = async () => [item];
   mockModels.Cart.findByPk = async () => ({
@@ -63,6 +66,34 @@ test('addItem rejects negative quantities', async () => {
 
   assert.ok(error instanceof ApiError);
   assert.match(error.message, /quantity must be positive/);
+});
+
+// Validar maxQtyPerOrder
+test('addItem respects maxQtyPerOrder', async () => {
+  const item = { quantity: 0, unitPrice: 0, subtotal: 0, displayName: '', thumbnailUrl: '', save: async function(){ return this; }, cartId: 1, productId: 1 };
+  mockModels.Product.findByPk = async () => ({ id: 1, price: 10, stock: 10, maxQtyPerOrder: 2, name: 'Brick', imageUrl: 'brick.png', status: 'active' });
+  mockModels.Cart.findOrCreate = async () => [{ id: 1 }];
+  mockModels.CartItem.findOrCreate = async () => [item];
+  let error;
+  const req = { user: { id: 1 }, body: { productId: 1, quantity: 3 } };
+  const res = { json: () => {} };
+  await addItem(req, res, (err) => { error = err; });
+  assert.ok(error instanceof ApiError);
+  assert.match(error.message, /max qty per order/i);
+});
+
+// Validar status discontinued
+test('addItem rejects discontinued products', async () => {
+  const item = { quantity: 0, unitPrice: 0, subtotal: 0, displayName: '', thumbnailUrl: '', save: async function(){ return this; }, cartId: 1, productId: 1 };
+  mockModels.Product.findByPk = async () => ({ id: 1, price: 10, stock: 5, status: 'discontinued', name: 'Brick', imageUrl: 'brick.png' });
+  mockModels.Cart.findOrCreate = async () => [{ id: 1 }];
+  mockModels.CartItem.findOrCreate = async () => [item];
+  let error;
+  const req = { user: { id: 1 }, body: { productId: 1, quantity: 1 } };
+  const res = { json: () => {} };
+  await addItem(req, res, (err) => { error = err; });
+  assert.ok(error instanceof ApiError);
+  assert.match(error.message, /discontinued/);
 });
 
 // Eliminar artículo del carrito
@@ -111,7 +142,8 @@ test('getCart returns items with expected shape', async () => {
     id: 42,
     quantity: 3,
     unitPrice: '5.00',
-    Product: { name: 'Brick', imageUrl: 'brick.png' },
+    displayName: 'Brick',
+    thumbnailUrl: 'brick.png',
   };
   mockModels.Cart.findOne = async () => ({
     toJSON() {
@@ -125,13 +157,13 @@ test('getCart returns items with expected shape', async () => {
   await getCart(req, res, (err) => { if (err) throw err; });
 
   assert.deepStrictEqual(output.items, [
-    { id: 42, name: 'Brick', imageUrl: 'brick.png', unitPrice: 5, quantity: 3 },
+    { id: 42, displayName: 'Brick', thumbnailUrl: 'brick.png', unitPrice: 5, quantity: 3 },
   ]);
   assert.strictEqual(output.total, 15);
-  // Ensure no extra properties like Product are leaked
+  // Ensure no extra properties are leaked
   assert.deepStrictEqual(
     Object.keys(output.items[0]).sort(),
-    ['id', 'imageUrl', 'name', 'quantity', 'unitPrice'].sort()
+    ['displayName', 'id', 'quantity', 'thumbnailUrl', 'unitPrice'].sort()
   );
 });
 


### PR DESCRIPTION
## Summary
- Calculate cart item price from product's effective sale or MSRP
- Snapshot product name and image into cart items
- Validate stock, max quantity per order, and discontinued status when modifying cart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae7fc14b4c83238bec52f2c675eb54